### PR TITLE
Changing pytest version to jive with astropy 2.0

### DIFF
--- a/.github/workflows/on_pr_test_python_37.yml
+++ b/.github/workflows/on_pr_test_python_37.yml
@@ -55,7 +55,8 @@ jobs:
         python -m pip install scipy==${{ matrix.scipy-version }}.* --no-deps
         python -m pip install astropy==${{ matrix.astropy-version }}.* --no-deps
         python -m pip install matplotlib==${{ matrix.mpl-version }}.* --no-deps
-        python -m pip install rebound requests pytest sympy tqdm corner pyyaml pyerfa pipdeptree
+        python -m pip install "pytest>=2.8,<3.7" --no-deps
+        python -m pip install rebound requests sympy tqdm corner pyyaml pyerfa pipdeptree
 
     - name: Run pipdeptree to see package dependencies
       run: |


### PR DESCRIPTION
Astropy 2.0 is only supported on python 3.7, so this is the only CI rule that needs to be changed.